### PR TITLE
fix: add curl and jq to Containerfile builder stage

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -6,7 +6,7 @@ ARG CONTAINER_VERSION=13.3
 FROM golang:1.25-trixie AS builder
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends git \
+ && apt-get install -y --no-install-recommends curl git jq \
  && rm -rf /var/lib/apt/lists/*
 
 # Resolve the latest CoreDNS release tag and clone at that version.


### PR DESCRIPTION
## Summary

The CI build was failing on both `amd64` and `arm64` with:

```
ERROR: failed to resolve latest CoreDNS release from GitHub API
```

## Root Cause

The `golang:1.25-trixie` builder image does not ship `curl` or `jq`. The version-resolution step in the builder stage pipes a `curl` call through `jq` to extract the latest CoreDNS release tag — but neither tool was installed, so the result was empty and the guard condition triggered an early exit.

## Fix

Add `curl` and `jq` to the builder stage `apt-get install`:

```diff
-  && apt-get install -y --no-install-recommends git \
+  && apt-get install -y --no-install-recommends curl git jq \
```

## AC Self-Review
- [x] Build no longer fails at the COREDNS_VERSION resolution step
- [x] curl and jq available in builder stage before they are used
- [x] hadolint passes clean

## Risk
Low — single-line addition to the builder stage only; runtime image unchanged.